### PR TITLE
CI: create kubeconfig

### DIFF
--- a/.github/workflows/common/terraform-s3-setup/action.yaml
+++ b/.github/workflows/common/terraform-s3-setup/action.yaml
@@ -38,6 +38,14 @@ runs:
       with:
         version: 'v3.7.3'
 
+    - name: Write kubeconfig
+      if: write-kubeconfig
+      shell: bash
+      run: |
+        echo $KUBECONFIG_CONTENT > ./.kubeconfig
+        export KUBECONFIG=$(pwd)/.kubeconfig
+        export KUBE_CONFIG_PATH=$(pwd)/.kubeconfig
+
     - name: Initialize terraform
       shell: bash
       run: terraform init

--- a/.github/workflows/common/terraform-s3-setup/action.yaml
+++ b/.github/workflows/common/terraform-s3-setup/action.yaml
@@ -39,7 +39,7 @@ runs:
         version: 'v3.7.3'
 
     - name: Write kubeconfig
-      if: write-kubeconfig
+      id: write-kubeconfig
       shell: bash
       run: |
         echo $KUBECONFIG_CONTENT > ./.kubeconfig


### PR DESCRIPTION
Due to behaviour unknown when starting this project, the kubernetes terraform provider needs the kubeconfig and according env vars set to work correctly. If the kubeconfig is not present the provider cannot authenticate to the cluster.

I added the required steps in the `terraform-s3-setup` action